### PR TITLE
Mac -nosudo

### DIFF
--- a/src/mac.ts
+++ b/src/mac.ts
@@ -34,7 +34,7 @@ export class MacPlatform extends PlatformCommands {
             }
         }
 
-        // Add -nosudo given not required with above chown
+        // Ensure '-nosudo' flag is present since sudo is unnecessary after chown
         if (!args.includes('-nosudo')) {
             args.push('-nosudo');
         }

--- a/src/mac.ts
+++ b/src/mac.ts
@@ -34,6 +34,11 @@ export class MacPlatform extends PlatformCommands {
             }
         }
 
+        // Add -nosudo given not required with above chown
+        if (!args.includes('-nosudo')) {
+            args.push('-nosudo');
+        }
+
         // Create the launchd plist file
         const plistFileContents = [
             '<?xml version="1.0" encoding="UTF-8"?>',


### PR DESCRIPTION
```
spawn [15:31:49.673] [Matterbridge:spawn] sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helpersudo: a password is required
spawn [15:31:49.674] [Matterbridge:spawn] child process exited with code 1 and signal null
error [15:31:49.674] [Matterbridge] Child process "npm install -g matterbridge --omit=dev --verbose" exited with code 1 and signal null
```